### PR TITLE
udev: implement compatibility with systemd-logind

### DIFF
--- a/71-hsdaoh.rules
+++ b/71-hsdaoh.rules
@@ -16,10 +16,10 @@
 #
 
 # MS2130
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="345f", ATTRS{idProduct}=="2130", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="345f", ATTRS{idProduct}=="2130", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 
 # MS2130 OEM
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="534d", ATTRS{idProduct}=="2130", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="534d", ATTRS{idProduct}=="2130", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 
 # MS2131
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="345f", ATTRS{idProduct}=="2131", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="345f", ATTRS{idProduct}=="2131", ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ add_custom_target(uninstall
 option(INSTALL_UDEV_RULES "Install udev rules" ON)
 if (INSTALL_UDEV_RULES)
     install (
-        FILES hsdaoh.rules
+        FILES 71-hsdaoh.rules
         DESTINATION "/etc/udev/rules.d"
         COMPONENT "udev"
         )

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To build hsdaoh:
     sudo make install
     sudo ldconfig
 
-To be able to access the USB device as non-root, the udev rules need to be installed (either use -DINSTALL_UDEV_RULES=ON or manually copy hsdaoh.rules to /etc/udev/rules.d/).
+To be able to access the USB device as non-root, the udev rules need to be installed (either use -DINSTALL_UDEV_RULES=ON or manually copy 71-hsdaoh.rules to /etc/udev/rules.d/).
 
 Before being able to use the device as a non-root user, the udev rules need to be reloaded:
 


### PR DESCRIPTION
systemd-logind uses the udev tag "uaccess" to make devices accessible to logged-in users. For this to work, the rule needs to be evaluated after 70-uaccess.rules and before 73-seat-late.rules.